### PR TITLE
bugfix: call user defined functions in train method

### DIFF
--- a/dissolve-struct-lib/src/main/scala/ch/ethz/dalab/dissolve/classification/MultiClassSVMWithDBCFW.scala
+++ b/dissolve-struct-lib/src/main/scala/ch/ethz/dalab/dissolve/classification/MultiClassSVMWithDBCFW.scala
@@ -162,14 +162,15 @@ object MultiClassSVMWithDBCFW extends DissolveFunctions[Vector[Double], MultiCla
    */
   def train(
     data: RDD[LabeledPoint],
-    featureFn: (Vector[Double], MultiClassLabel) => Vector[Double], // (y, x) => FeatureVector
-    lossFn: (MultiClassLabel, MultiClassLabel) => Double, // (yTruth, yPredict) => LossValue
-    oracleFn: (StructSVMModel[Vector[Double], MultiClassLabel], Vector[Double], MultiClassLabel) => MultiClassLabel, // (model, y_i, x_i) => Label
-    predictFn: (StructSVMModel[Vector[Double], MultiClassLabel], Vector[Double]) => MultiClassLabel,
+    dissolveFunctions: DissolveFunctions[Vector[Double], MultiClassLabel],
+    //featureFn: (Vector[Double], MultiClassLabel) => Vector[Double], // (y, x) => FeatureVector
+    //lossFn: (MultiClassLabel, MultiClassLabel) => Double, // (yTruth, yPredict) => LossValue
+    //oracleFn: (StructSVMModel[Vector[Double], MultiClassLabel], Vector[Double], MultiClassLabel) => MultiClassLabel, // (model, y_i, x_i) => Label
+    //predictFn: (StructSVMModel[Vector[Double], MultiClassLabel], Vector[Double]) => MultiClassLabel,
     solverOptions: SolverOptions[Vector[Double], MultiClassLabel]): StructSVMModel[Vector[Double], MultiClassLabel] = {
 
     val numClasses = solverOptions.numClasses
-    assert(numClasses < 1)
+    assert(numClasses > 1)
 
     val minlabel = data.map(_.label).min()
     val maxlabel = data.map(_.label).max()
@@ -198,7 +199,7 @@ object MultiClassSVMWithDBCFW extends DissolveFunctions[Vector[Double], MultiCla
 
     val (trainedModel, debugInfo) = new DBCFWSolverTuned[Vector[Double], MultiClassLabel](
       repartData,
-      this,
+      dissolveFunctions,
       solverOptions,
       miniBatchEnabled = false).optimize()
 


### PR DESCRIPTION
The second train method should allow the user to use its own HelperFunctions. However the DBCFWSolver is called using the HelperFunctions defined in MultiClassSVMWithDBCFW which ignores the user defined functions.

I changed the parameters to include an object of type HelperFunction[Vector[Double],MultiClassLabel] which is then passed to the DBCFWSolver.

I changed the assertion to check if the number of classes is greater than 1 instead of smaller than 1.